### PR TITLE
Update dependencies package fibers to 3.0.0 to have prebuilt fibers binary for Node 10.

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -10,6 +10,6 @@
   "plugins": [
     "rewire",
     "transform-runtime",
-    "add-module-exports",
+    "add-module-exports"
   ]
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 
 node_js:
-  - '6.10'
+  - '8'
 
 script:
   - npm run test:ci

--- a/package-lock.json
+++ b/package-lock.json
@@ -2389,9 +2389,9 @@
       "dev": true
     },
     "fibers": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fibers/-/fibers-2.0.0.tgz",
-      "integrity": "sha512-sLxo4rZVk7xLgAjb/6zEzHJfSALx6u6coN1z61XCOF7i6CyTdJawF4+RdpjCSeS8AP66eR2InScbYAz9RAVOgA=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/fibers/-/fibers-3.0.0.tgz",
+      "integrity": "sha512-cAcOHOTbTMlcpNZvr94BNFsnBDBiEu9JP5MYcRLyl12HF/X0z3KvZyNzU9+BtI8lOIaV84PlDQJOKK3f5llJug=="
     },
     "figures": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "homepage": "https://github.com/webdriverio/wdio-sync#readme",
   "dependencies": {
     "babel-runtime": "^6.26.0",
-    "fibers": "~2.0.0",
+    "fibers": "^3.0.0",
     "object.assign": "^4.0.3"
   },
   "contributors": [


### PR DESCRIPTION
The wdio-mocha-framework cannot be installed on Node 10 environment, because it depends on wdio-sync, and wdio-sync has a dependence, fiber. The fiber 2.x doesn't provide prebuilt binaries for Node 10, but fiber 3.0.0 does.

This PR fixed issue #133.